### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,33 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a zero-dependency bash + Python project (no package manager, no lockfiles). The core product is `claude-status.sh`, a terminal dashboard for monitoring Claude service status.
+
+### Running the application
+
+```bash
+./claude-status.sh
+```
+
+The script runs in a loop (refreshes every 30s). Press `q` to quit, `r` to refresh manually.
+
+### Linting
+
+- **Shell**: `shellcheck claude-status.sh` (warnings are informational; the CI only runs `bash -n claude-status.sh` for syntax validation)
+- **Python**: The embedded Python in `claude-status.sh` uses only stdlib (`json`, `urllib.request`, `re`, `sys`, `os`). No external packages needed.
+- There is no formal test suite — the CI workflow (`.github/workflows/health-check.yml`) validates the API fetch, JSON structure, uptime scraping, and shell syntax.
+
+### CI checks (reproducible locally)
+
+```bash
+bash -n claude-status.sh                              # shell syntax check
+shellcheck claude-status.sh                           # static analysis (informational warnings only)
+curl -s "https://status.claude.com/api/v2/summary.json" | python3 -m json.tool > /dev/null  # API reachable
+```
+
+### Platform notes
+
+- The macOS menubar app (`ClaudeStatusMenubar.swift`) and icon generator (`generate-icon.py`) require macOS + Swift/Xcode CLI tools + Pillow. These cannot be built on Linux.
+- On Linux (Cloud Agent VMs), only the terminal dashboard is runnable.
+- The script fetches live data from `status.claude.com` — it requires network access to function.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with development environment instructions for Cursor Cloud agents.

## What this adds

- Instructions for running the terminal dashboard (`./claude-status.sh`)
- Linting commands (`shellcheck`, `bash -n`)
- CI check reproduction commands
- Platform notes (Linux vs macOS limitations)

## Demo

[claude_status_dashboard_demo.mp4](https://cursor.com/agents/bc-a2072571-bf9c-4274-a4e5-e2e4346d15f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fclaude_status_dashboard_demo.mp4)

[Claude Status Terminal Dashboard showing all services with 90-day uptime bars](https://cursor.com/agents/bc-a2072571-bf9c-4274-a4e5-e2e4346d15f4/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_full.webp)

The terminal dashboard fetches live data from status.claude.com, displays 6 service statuses with colored 90-day uptime bars, shows active incidents and scheduled maintenance, and refreshes on demand.

## Environment verification

- `bash -n claude-status.sh` — shell syntax valid
- `shellcheck claude-status.sh` — informational warnings only (no errors)
- API fetch → HTTP 200, valid JSON with 6 components
- Uptime history scraping → 90 days of data for all 6 components
- Dashboard runs, auto-refreshes, and responds to keyboard input

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a2072571-bf9c-4274-a4e5-e2e4346d15f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a2072571-bf9c-4274-a4e5-e2e4346d15f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

