### PR TITLE
Add AGENTS.md with Cursor Cloud development instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,25 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This is a macOS-focused project (Claude Status Terminal) with no package manager, no build system beyond shell scripts, and no automated test suite. The core product is `claude-status.sh`, a bash script with inline Python 3 that fetches live data from `status.claude.com`.
+
+### Platform constraints
+
+- The **menubar app** (`ClaudeStatusMenubar.swift`) and **icon generator** (`generate-icon.py` → `iconutil`) require macOS + Xcode CLI tools. These cannot be built or tested on Linux.
+- The **terminal dashboard** (`claude-status.sh`) runs on Linux with Python 3 + curl + bash and is the primary component to validate.
+
+### Validation commands (Linux-compatible)
+
+- **Shell syntax check:** `bash -n claude-status.sh`
+- **API reachability + JSON structure:** replicate the steps in `.github/workflows/health-check.yml` (`api-check` job) using `python3` and `curl`.
+- **Uptime scrape check:** fetch `https://status.claude.com/` and verify `uptimeData` JSON is parseable.
+- **Run the dashboard (single render):** execute the inline Python block from `claude-status.sh` directly, since the full script enters an interactive loop with `tput civis` / key reads that require a TTY.
+
+### No linter or test framework
+
+There is no linter, formatter, or test framework configured. The CI workflow (`.github/workflows/health-check.yml`) performs the only automated checks: API validation, uptime scrape, shell syntax, and macOS-only build verification.
+
+### Running the dashboard interactively
+
+To run `./claude-status.sh` interactively (with auto-refresh and key bindings), a real terminal (TTY) is required. In headless environments, extract and run the `render()` function's Python block directly for a single-shot render.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents working on this codebase.

### What's included

- Platform constraints (macOS-only components vs Linux-compatible terminal dashboard)
- Linux-compatible validation commands (shell syntax check, API validation, uptime scrape)
- Notes on the lack of linter/test framework and how CI handles checks
- Guidance for running the dashboard in headless environments

### Why

This file helps future cloud agents understand the codebase structure and know which components can be validated on Linux without wasting time trying to build macOS-only artifacts.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ea7da534-326d-414e-aca2-8159768788af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ea7da534-326d-414e-aca2-8159768788af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

