### PR TITLE
INF-482 durable webhook smoke 20260616-073014

### DIFF
--- a/docs/watson-smoke/inf-482-durable-20260616-073014.md
+++ b/docs/watson-smoke/inf-482-durable-20260616-073014.md
@@ -1,0 +1,7 @@
+# INF-482 durable webhook smoke
+
+Created by Watson to fire a real non-ops GitHub pull_request webhook through Tailscale Funnel.
+
+UTC: 20260616-073014
+
+This PR should be closed/deleted after webhook proof is captured.


### PR DESCRIPTION
INF-482 durable ingress smoke. This PR exists only to fire one real non-ops pull_request webhook through the Tailscale Funnel URL, then it will be closed and branch-deleted after proof capture.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only smoke artifact with no runtime, auth, or data-path changes.
> 
> **Overview**
> Adds a **throwaway smoke-test PR** for INF-482: a short note in `docs/watson-smoke/inf-482-durable-20260616-073014.md` documenting that Watson opened this PR to trigger a real non-ops `pull_request` GitHub webhook via **Tailscale Funnel** (timestamp `20260616-073014`).
> 
> No application or infrastructure code changes—only the doc. The PR is meant to be **closed and the branch deleted** after webhook proof is captured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 955584a51bc827afaff8c2321c4526d81f21915e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->