### PR TITLE
INF-482 Bugbot/Cursor capture probe — do not merge

### DIFF
--- a/inf482_bugbot_capture_probe.py
+++ b/inf482_bugbot_capture_probe.py
@@ -1,0 +1,22 @@
+"""INF-482 Bugbot/Cursor webhook capture probe.
+
+This file is intentionally not imported by the app. It contains a very
+obvious benign bug so PR review automation has something safe to notice.
+Do not merge this PR; close it after webhook/event-shape capture.
+"""
+
+
+def percent_available(used: int, total: int) -> float:
+    """Return available capacity as a percentage.
+
+    Intentional benign bug for INF-482 capture: this returns the used
+    percentage instead of the available percentage. For used=25,total=100,
+    it returns 25.0 but should return 75.0.
+    """
+    if total <= 0:
+        return 0.0
+    return (used / total) * 100
+
+
+if __name__ == "__main__":
+    print(percent_available(25, 100))


### PR DESCRIPTION
## Purpose
INF-482 webhook capture probe. This PR deliberately adds a tiny, obvious, benign bug in an unreferenced probe file so Cursor/Bugbot/Approval-Agent review automation has something safe to notice.

## Intentional bug
`percent_available(25, 100)` returns `25.0` but should return `75.0` because the function returns used percent, not available percent.

## Safety
- Do not merge.
- No production code path imports this file.
- Close/delete branch after event-shape capture.

INF-482

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Isolated, unreferenced probe file with no production imports; changes are explicitly non-mergeable test harness only.
> 
> **Overview**
> Adds a **standalone probe module** `inf482_bugbot_capture_probe.py` for INF-482 webhook/event-shape capture. The file is **not imported** by the app and is meant to be closed without merging.
> 
> The probe defines `percent_available(used, total)` with a **documented intentional bug**: it returns **used** capacity as a percent (`used/total*100`) while the name/docstring say **available** (e.g. 25/100 → `25.0` instead of `75.0`). A `__main__` block prints that example for local runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f6a2a313f8f536293025aac0f93a858330193051. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->