### PR TITLE
ci: fix org gitleaks workflow

### DIFF
--- a/.github/workflows/gitleaks.yml
+++ b/.github/workflows/gitleaks.yml
@@ -1,10 +1,13 @@
 name: gitleaks
 # Hard enforcement: scan every push + PR for leaked secrets.
-# Free for personal-account repos (adversarydsgn) — no GITLEAKS_LICENSE needed.
+# Uses the open-source gitleaks CLI directly so org repos do not require the licensed GitHub Action.
 on:
   push:
   pull_request:
   workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   scan:
@@ -14,6 +17,13 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 0
-      - uses: gitleaks/gitleaks-action@v2
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Install gitleaks CLI
+        run: |
+          set -euo pipefail
+          version="8.28.0"
+          curl -sSfL "https://github.com/gitleaks/gitleaks/releases/download/v${version}/gitleaks_${version}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp gitleaks
+          sudo install -m 0755 /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+      - name: Run gitleaks
+        run: gitleaks detect --source . --redact --verbose

--- a/.github/workflows/health-check.yml
+++ b/.github/workflows/health-check.yml
@@ -190,7 +190,7 @@ jobs:
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 title: title,
-                body: `The daily health check failed. [View the run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).\n\nThis could mean:\n- The status.claude.com API changed its response format\n- The uptime history HTML structure changed\n- The Swift compilation broke on a new macOS version\n\ncc @adversarydsgn`,
+                body: `The daily health check failed. [View the run](${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}).\n\nThis could mean:\n- The status.claude.com API changed its response format\n- The uptime history HTML structure changed\n- The Swift compilation broke on a new macOS version\n\ncc @adversarydesign`,
                 labels: ['health-check', 'bug']
               });
             }


### PR DESCRIPTION
Replaces the licensed gitleaks GitHub Action with the open-source CLI path so the repo continues to scan after moving under the adversarydesign org. Also cleans remaining owner references.